### PR TITLE
Remove version constraints.

### DIFF
--- a/s3-sns-notification.cabal
+++ b/s3-sns-notification.cabal
@@ -22,11 +22,11 @@ library
   exposed-modules:     Network.AWS.SNS.Notification.S3
   -- other-modules:
   build-depends:
-    base >=4.12 && <4.13,
-    lens >=4.17 && <4.18,
-    aeson >=1.4 && <1.5,
-    text >=1.2 && <1.3,
-    time >=1.8 && <1.9
+    base,
+    lens,
+    aeson,
+    text,
+    time
   hs-source-dirs:      src
   ghc-options: -Wall -fwarn-redundant-constraints
   default-language:    Haskell2010


### PR DESCRIPTION
##### SUMMARY

fld-ks uses nix to manage dependencies, build, deploy, etc. It uses a pinned version of nixpkgs (https://github.com/Feeld/fld-ks/compare/damianfral/update/nixpkgs#diff-990d93ae620a3c4824fd6544548bf806L10) so we have deterministic builds. We also pin concrete versions of some dependencies. This repo is one of its dependencies, and in its cabal file, we constraint haskell dependencies versions, but we don't use cabal to fetch packages. That's something nix provides.

So, when we want to update dependencies, we update nixpkgs. If we keep the cabal version constraints, we have to manually check these constraints and see if we need to update them to use the latest version. It's easier to update nixpkgs and remove the contraints and we automatically are gonna be using latest versions everywhere. Then, when building, we may have some conflicts, and then we pin concrete versions of packages.